### PR TITLE
Add voice input and Google Calendar sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Create `.env.local` and set:
+   - `GEMINI_API_KEY` – key for Gemini image generation
+   - `GOOGLE_API_KEY` and `GOOGLE_CLIENT_ID` – credentials for Google Calendar API
+   - `GOOGLE_CALENDAR_ID` – ID of the calendar to sync against
 3. Run the app:
    `npm run dev`
+
+## Features
+
+* **Google Calendar sync** – press *Koppla Google* in the header to authorize and load events from the configured calendar. New events are also inserted into Google Calendar.
+* **Voice input** – use the microphone button in the chat window to dictate messages via the browser's speech recognition (sv-SE).
+* **Automatic event images** – when an event is saved, an image is generated using Gemini Imagen to provide visual support.

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -41,3 +41,10 @@ export const PhotoIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
     <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909m-18 3.75h16.5a1.5 1.5 0 001.5-1.5V6a1.5 1.5 0 00-1.5-1.5H3.75A1.5 1.5 0 002.25 6v12a1.5 1.5 0 001.5 1.5zm10.5-11.25h.008v.008h-.008V8.25zm.375 0a.375.375 0 11-.75 0 .375.375 0 01.75 0z" />
   </svg>
 );
+
+export const MicrophoneIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M12 1.5a3 3 0 00-3 3v6a3 3 0 006 0v-6a3 3 0 00-3-3z" />
+    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 10.5v1a7.5 7.5 0 01-15 0v-1m7.5 7.5V21m0 0h3m-3 0H9" />
+  </svg>
+);

--- a/hooks/useGoogleCalendar.ts
+++ b/hooks/useGoogleCalendar.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { CalendarEvent } from '../types';
+
+// Allow TypeScript to recognise gapi on window
+declare global {
+  interface Window {
+    gapi: any;
+  }
+}
+
+const SCOPES = 'https://www.googleapis.com/auth/calendar';
+
+export const useGoogleCalendar = () => {
+  const [isSignedIn, setIsSignedIn] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    const script = document.createElement('script');
+    script.src = 'https://apis.google.com/js/api.js';
+    script.onload = () => {
+      window.gapi.load('client:auth2', async () => {
+        try {
+          await window.gapi.client.init({
+            apiKey: process.env.GOOGLE_API_KEY,
+            clientId: process.env.GOOGLE_CLIENT_ID,
+            discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'],
+            scope: SCOPES,
+          });
+          const auth = window.gapi.auth2.getAuthInstance();
+          setIsSignedIn(auth.isSignedIn.get());
+          auth.isSignedIn.listen(setIsSignedIn);
+          setIsReady(true);
+        } catch (e) {
+          console.error('Failed to init Google API', e);
+        }
+      });
+    };
+    document.body.appendChild(script);
+  }, []);
+
+  const signIn = () => {
+    if (isReady) {
+      window.gapi.auth2.getAuthInstance().signIn();
+    }
+  };
+
+  const listEvents = async (calendarId: string): Promise<CalendarEvent[]> => {
+    if (!isReady || !isSignedIn) return [];
+    const res = await window.gapi.client.calendar.events.list({
+      calendarId,
+      timeMin: new Date().toISOString(),
+      singleEvents: true,
+      orderBy: 'startTime',
+    });
+    const items = res.result.items || [];
+    return items.map((item: any) => {
+      const start = item.start?.dateTime || item.start?.date;
+      const end = item.end?.dateTime || item.end?.date;
+      return {
+        id: item.id,
+        title: item.summary || 'Untitled',
+        date: start?.slice(0, 10),
+        time: start?.length > 10 ? start.slice(11, 16) : undefined,
+        endTime: end?.length > 10 ? end.slice(11, 16) : undefined,
+        description: item.description,
+        color: 'bg-blue-500',
+      } as CalendarEvent;
+    });
+  };
+
+  const addEvent = async (calendarId: string, event: CalendarEvent) => {
+    if (!isReady || !isSignedIn) return;
+    const startDateTime = event.time ? `${event.date}T${event.time}:00` : `${event.date}T00:00:00`;
+    const endDateTime = event.endTime ? `${event.date}T${event.endTime}:00` : undefined;
+    await window.gapi.client.calendar.events.insert({
+      calendarId,
+      resource: {
+        summary: event.title,
+        description: event.description,
+        start: { dateTime: startDateTime },
+        end: { dateTime: endDateTime || startDateTime },
+      },
+    });
+  };
+
+  return { isReady, isSignedIn, signIn, listEvents, addEvent };
+};

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "react-dom": "^19.1.0",
     "react": "^19.1.0",
     "date-fns": "^4.1.0",
-    "@google/genai": "latest",
-    "date-fns/isValid": "^4.1.0"
+    "@google/genai": "latest"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/gapi": "^0.0.47",
+    "@types/gapi.client.calendar": "^3.0.6",
     "typescript": "~5.7.2",
     "vite": "^6.2.0"
   }


### PR DESCRIPTION
## Summary
- integrate Google Calendar API and sign-in hook
- add microphone voice input for chat
- auto-generate event images with Gemini

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689791d72ff883249e22497c6e9a50cd